### PR TITLE
revert(serverless.yml): revert resource attribution in IAM role statements

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -61,18 +61,18 @@ provider:
             - xray:PutTraceSegments
             - xray:PutTelemetryRecords
           Resource:
-            - !Ref SquadConfigurationTable
+            - "Fn::GetAtt": [ SquadConfigurationTable, Arn ]
         - Effect: Allow
           Action:
             - sns:Publish
             - sns:Subscribe
           Resource:
-            - !Ref ReportTopic
+            - "Fn::GetAtt": [ ReportTopic, Arn ]
         - Effect: Allow
           Action:
             - sqs:SendMessage
           Resource:
-            - !Ref ReportDLQ
+            - "Fn::GetAtt": [ ReportDLQ, Arn ]
 
 functions:
   Produce:


### PR DESCRIPTION
Reverted from using `!Ref` to `Fn::GetAtt`